### PR TITLE
Add GPSHPositioningError tag defined in exif version 2.3.1

### DIFF
--- a/libexif/exif-tag.c
+++ b/libexif/exif-tag.c
@@ -217,6 +217,9 @@ static const struct TagEntry {
 	{EXIF_TAG_GPS_DIFFERENTIAL, "GPSDifferential", N_("GPS Differential Correction"),
          N_("Indicates whether differential correction is applied to the "
             "GPS receiver."), ESL_GPS},
+	{EXIF_TAG_GPS_H_POSITIONING_ERROR, "GPSHPositioningError", N_("GPS Horizontal Positioning Error"),
+         N_("Indicates the horizontal positioning errors in meters. This is "
+            "expressed as one RATIONAL value."), ESL_GPS},
 	/* Not in EXIF 2.2 */
 	{EXIF_TAG_NEW_SUBFILE_TYPE, "NewSubfileType",
 	 N_("New Subfile Type"), N_("A general indication of the kind of data "

--- a/libexif/exif-tag.h
+++ b/libexif/exif-tag.h
@@ -183,6 +183,7 @@ typedef enum {
 #define EXIF_TAG_GPS_AREA_INFORMATION   0x001c
 #define EXIF_TAG_GPS_DATE_STAMP         0x001d
 #define EXIF_TAG_GPS_DIFFERENTIAL       0x001e
+#define EXIF_TAG_GPS_H_POSITIONING_ERROR 0x001f
 
 /*! What level of support a tag enjoys in the EXIF standard */
 typedef enum {


### PR DESCRIPTION
See http://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf, page 77.

This tag is already supported on mobile SDKs:

Android:
https://developer.android.com/reference/android/support/media/ExifInterface#TAG_GPS_H_POSITIONING_ERROR

iOS:
https://developer.apple.com/documentation/imageio/kcgimagepropertygpshpositioningerror?language=objc