### PR TITLE
Fix "make check" with mingw

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -208,7 +208,6 @@ AC_CONFIG_FILES([
   libexif.spec
   libexif/Makefile
   test/Makefile
-  test/check-vars.sh
   test/nls/Makefile
   m4m/Makefile
   doc/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,34 @@ LT_INIT([win32-dll])
 AM_CPPFLAGS="$CPPFLAGS"
 GP_CONFIG_MSG([Compiler], [${CC}])
 
+
+dnl --------------------------------------------------------------------
+dnl check for "diff" and "diff -u"
+dnl --------------------------------------------------------------------
+
+AC_ARG_VAR([DIFF], [path to diff utility (default: no)])
+AC_PATH_PROG([DIFF], [diff], [no])
+AM_CONDITIONAL([HAVE_DIFF], [test "x$DIFF" != xno])
+
+DIFF_U="no"
+AS_IF([test "x$DIFF" != xno], [dnl
+AC_MSG_CHECKING([whether diff supports -u])
+echo moo > conftest-a.c
+echo moo > conftest-b.c
+AS_IF([${DIFF} -u conftest-a.c conftest-b.c], [dnl
+  AC_MSG_RESULT([yes])
+  DIFF_U="$DIFF -u"
+], [dnl
+  AC_MSG_RESULT([no])
+])
+rm -f conftest-a.c conftest-b.c
+])
+AC_SUBST([DIFF_U])
+AM_CONDITIONAL([HAVE_DIFF_U], [test "x$DIFF_U" != xno])
+
+
+dnl --------------------------------------------------------------------
+
 AC_SYS_LARGEFILE
 
 dnl Create a stdint.h-like file containing size-specific integer definitions

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,16 @@
 SUBDIRS = nls
 
+# By default, a few definitions like bindir, srcdir are already set.
+AM_TESTS_ENVIRONMENT =
+
+# Run all tests without i18n and l10n for proper comparisons
+AM_TESTS_ENVIRONMENT += LC_ALL='C'; export LC_ALL;
+
+# Some AC_SUBST variables needed in test case scripts
+AM_TESTS_ENVIRONMENT += DIFF='$(DIFF)'; export DIFF;
+AM_TESTS_ENVIRONMENT += DIFF_U='$(DIFF_U)'; export DIFF_U;
+AM_TESTS_ENVIRONMENT += FAILMALLOC_PATH='$(FAILMALLOC_PATH)'; export FAILMALLOC_PATH;
+
 # Notes about tests:
 #  - Add "small" tests and stuff here.
 #  - Add "big"   tests and stuff to explicitly test for (fixed) bugs
@@ -24,8 +35,11 @@ check_PROGRAMS = test-mem test-mnote test-value test-integers test-parse \
 
 LDADD = $(top_builddir)/libexif/libexif.la $(LTLIBINTL)
 
-EXTRA_DIST = check-vars.sh.in parse-regression.sh swap-byte-order.sh \
-	extract-parse.sh check-failmalloc.sh \
+EXTRA_DIST = \
+	parse-regression.sh \
+	swap-byte-order.sh \
+	extract-parse.sh \
+	check-failmalloc.sh \
 	testdata/canon_makernote_variant_1.jpg \
 	testdata/canon_makernote_variant_1.jpg.parsed \
 	testdata/fuji_makernote_variant_1.jpg \

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -9,6 +9,7 @@ AM_TESTS_ENVIRONMENT += LC_ALL='C'; export LC_ALL;
 # Some AC_SUBST variables needed in test case scripts
 AM_TESTS_ENVIRONMENT += DIFF='$(DIFF)'; export DIFF;
 AM_TESTS_ENVIRONMENT += DIFF_U='$(DIFF_U)'; export DIFF_U;
+AM_TESTS_ENVIRONMENT += EXEEXT='$(EXEEXT)'; export EXEEXT;
 AM_TESTS_ENVIRONMENT += FAILMALLOC_PATH='$(FAILMALLOC_PATH)'; export FAILMALLOC_PATH;
 
 # Notes about tests:

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -26,9 +26,7 @@ TESTS = test-mem test-value test-integers test-parse test-tagtable test-sorted \
 	test-fuzzer test-null parse-regression.sh swap-byte-order.sh \
 	extract-parse.sh
 
-if USE_FAILMALLOC
 TESTS += check-failmalloc.sh
-endif
 
 check_PROGRAMS = test-mem test-mnote test-value test-integers test-parse \
 	test-tagtable test-sorted test-fuzzer test-extract test-null

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -58,3 +58,5 @@ EXTRA_DIST = \
 	testdata/pentax_makernote_variant_3.jpg.parsed \
 	testdata/pentax_makernote_variant_4.jpg \
 	testdata/pentax_makernote_variant_4.jpg.parsed
+
+EXTRA_DIST += inc-comparetool.sh

--- a/test/check-failmalloc.sh
+++ b/test/check-failmalloc.sh
@@ -17,9 +17,8 @@ if [ "$1" = "-v" ] ; then
 fi
 
 if [ x"$FAILMALLOC_PATH" = x ]; then
-    echo libfailmalloc is not available
-    echo SKIPPING
-    exit
+    echo "libfailmalloc is not available"
+    exit 77
 fi
 
 BINARY_PREFIX=./

--- a/test/check-failmalloc.sh
+++ b/test/check-failmalloc.sh
@@ -7,10 +7,9 @@
 # Ideally, it would ensure that the test binary returns an error code on each
 # failure, but this often doesn't happen. This is a problem that should be
 # rectified, but the API doesn't allow returning an error code in many
-# functions that could encounter a problem. The issue could be solve in more
+# functions that could encounter a problem. The issue could be solved in more
 # cases with more judicious use of log calls with EXIF_LOG_CODE_NO_MEMORY
 # codes.
-. ./check-vars.sh
 
 VERBOSE=
 if [ "$1" = "-v" ] ; then
@@ -62,7 +61,7 @@ failmalloc_binary_test () {
 
 failmalloc_binary_test 500 test-value
 failmalloc_binary_test 300 test-mem
-for f in $SRCDIR/testdata/*jpg; do
+for f in ${srcdir}/testdata/*jpg; do
     echo "Testing `basename "$f"`"
     failmalloc_binary_test 500 test-parse "$f"
     # N.B., test-parse --swap-byte-order doesn't test any new paths

--- a/test/check-failmalloc.sh
+++ b/test/check-failmalloc.sh
@@ -62,8 +62,8 @@ failmalloc_binary_test 500 test-value
 failmalloc_binary_test 300 test-mem
 for f in ${srcdir}/testdata/*jpg; do
     echo "Testing `basename "$f"`"
-    failmalloc_binary_test 500 test-parse "$f"
-    # N.B., test-parse --swap-byte-order doesn't test any new paths
+    failmalloc_binary_test 500 test-parse$EXEEXT "$f"
+    # N.B., test-parse$EXEEXT --swap-byte-order doesn't test any new paths
 done
 
 echo PASSED

--- a/test/check-vars.sh.in
+++ b/test/check-vars.sh.in
@@ -1,4 +1,0 @@
-# Specifies autoconf variables for use by the test scripts
-
-SRCDIR=@srcdir@
-FAILMALLOC_PATH=@FAILMALLOC_PATH@

--- a/test/extract-parse.sh
+++ b/test/extract-parse.sh
@@ -23,6 +23,8 @@ parse_canonicalize () {
         -e '/MakerNote (Undefined)$/{N;N;d}'
 }
 
+. ${srcdir}/inc-comparetool.sh
+
 # Ensure that names are untranslated
 LANG=
 LANGUAGE=
@@ -32,7 +34,9 @@ for fn in "${srcdir}"/testdata/*.jpg ; do
     ./test-parse "${fn}" | parse_canonicalize > "${TMPORIGINAL}"
     ./test-extract -o "${TMPDATA}" "${fn}"
     ./test-parse "${TMPDATA}" | parse_canonicalize > "${TMPEXTRACTED}"
-    if ! diff "${TMPORIGINAL}" "${TMPEXTRACTED}"; then
+    if ${comparetool} "${TMPORIGINAL}" "${TMPEXTRACTED}"; then
+	: "no differences detected"
+    else
         echo Error parsing "$fn"
         exit 1
     fi

--- a/test/extract-parse.sh
+++ b/test/extract-parse.sh
@@ -31,9 +31,9 @@ LANGUAGE=
 LC_ALL=C
 export LANG LANGUAGE LC_ALL
 for fn in "${srcdir}"/testdata/*.jpg ; do
-    ./test-parse$EXEEXT "${fn}" | parse_canonicalize > "${TMPORIGINAL}"
+    ./test-parse$EXEEXT "${fn}" | tr -d '\015' | parse_canonicalize > "${TMPORIGINAL}"
     ./test-extract$EXEEXT -o "${TMPDATA}" "${fn}"
-    ./test-parse$EXEEXT "${TMPDATA}" | parse_canonicalize > "${TMPEXTRACTED}"
+    ./test-parse$EXEEXT "${TMPDATA}" | tr -d '\015' | parse_canonicalize > "${TMPEXTRACTED}"
     if ${comparetool} "${TMPORIGINAL}" "${TMPEXTRACTED}"; then
 	: "no differences detected"
     else

--- a/test/extract-parse.sh
+++ b/test/extract-parse.sh
@@ -31,9 +31,9 @@ LANGUAGE=
 LC_ALL=C
 export LANG LANGUAGE LC_ALL
 for fn in "${srcdir}"/testdata/*.jpg ; do
-    ./test-parse "${fn}" | parse_canonicalize > "${TMPORIGINAL}"
-    ./test-extract -o "${TMPDATA}" "${fn}"
-    ./test-parse "${TMPDATA}" | parse_canonicalize > "${TMPEXTRACTED}"
+    ./test-parse$EXEEXT "${fn}" | parse_canonicalize > "${TMPORIGINAL}"
+    ./test-extract$EXEEXT -o "${TMPDATA}" "${fn}"
+    ./test-parse$EXEEXT "${TMPDATA}" | parse_canonicalize > "${TMPEXTRACTED}"
     if ${comparetool} "${TMPORIGINAL}" "${TMPEXTRACTED}"; then
 	: "no differences detected"
     else

--- a/test/inc-comparetool.sh
+++ b/test/inc-comparetool.sh
@@ -1,0 +1,15 @@
+# -*- sh -*-
+#
+# cmp(1) creates the same exit code as diff in case of files being
+# different or the same, even though the diff(1) output is more
+# informative
+
+if test "x$DIFF_U" != x && test "x$DIFF_U" != xno
+then
+    comparetool="$DIFF_U"
+elif test "x$DIFF" != x && test "x$DIFF" != xno
+then
+    comparetool="$DIFF"
+else
+    comparetool=cmp
+fi

--- a/test/parse-regression.sh
+++ b/test/parse-regression.sh
@@ -12,7 +12,7 @@ LANGUAGE=
 LC_ALL=C
 export LANG LANGUAGE LC_ALL
 for fn in "${srcdir}"/testdata/*.jpg ; do
-    ./test-parse "${fn}" > "${TMPLOG}"
+    ./test-parse$EXEEXT "${fn}" > "${TMPLOG}"
     if ${comparetool} "${fn}.parsed" "${TMPLOG}"; then
 	: "no differences detected"
     else

--- a/test/parse-regression.sh
+++ b/test/parse-regression.sh
@@ -3,6 +3,9 @@
 srcdir="${srcdir:-.}"
 TMPLOG="$(mktemp)"
 trap 'rm -f "${TMPLOG}"' 0
+
+. ${srcdir}/inc-comparetool.sh
+
 # Ensure that names are untranslated
 LANG=
 LANGUAGE=
@@ -10,8 +13,10 @@ LC_ALL=C
 export LANG LANGUAGE LC_ALL
 for fn in "${srcdir}"/testdata/*.jpg ; do
     ./test-parse "${fn}" > "${TMPLOG}"
-    if ! diff "${fn}".parsed "${TMPLOG}"; then
-        echo Error parsing "$fn"
+    if ${comparetool} "${fn}.parsed" "${TMPLOG}"; then
+	: "no differences detected"
+    else
+        echo "Error parsing $fn"
         exit 1
     fi
 done

--- a/test/parse-regression.sh
+++ b/test/parse-regression.sh
@@ -12,7 +12,10 @@ LANGUAGE=
 LC_ALL=C
 export LANG LANGUAGE LC_ALL
 for fn in "${srcdir}"/testdata/*.jpg ; do
-    ./test-parse$EXEEXT "${fn}" > "${TMPLOG}"
+    # The *.parsed text files have LF line endings, so the tr removes
+    # the CR from CRLF line endings, while keeping LF line endings the
+    # same.
+    ./test-parse$EXEEXT "${fn}" | tr -d '\015' > "${TMPLOG}"
     if ${comparetool} "${fn}.parsed" "${TMPLOG}"; then
 	: "no differences detected"
     else

--- a/test/swap-byte-order.sh
+++ b/test/swap-byte-order.sh
@@ -12,7 +12,7 @@ LANGUAGE=
 LC_ALL=C
 export LANG LANGUAGE LC_ALL
 for fn in "${srcdir}"/testdata/*.jpg ; do
-    ./test-parse --swap-byte-order "${fn}" | sed -e '/^New byte order:/d' > "${TMPLOG}"
+    ./test-parse$EXEEXT --swap-byte-order "${fn}" | sed -e '/^New byte order:/d' > "${TMPLOG}"
     if ${comparetool} "${fn}.parsed" "${TMPLOG}"; then
 	: "no differences detected"
     else

--- a/test/swap-byte-order.sh
+++ b/test/swap-byte-order.sh
@@ -12,7 +12,10 @@ LANGUAGE=
 LC_ALL=C
 export LANG LANGUAGE LC_ALL
 for fn in "${srcdir}"/testdata/*.jpg ; do
-    ./test-parse$EXEEXT --swap-byte-order "${fn}" | sed -e '/^New byte order:/d' > "${TMPLOG}"
+    # The *.parsed text files have LF line endings, so the tr removes
+    # the CR from CRLF line endings, while keeping LF line endings the
+    # same.
+    ./test-parse$EXEEXT --swap-byte-order "${fn}" | tr -d '\015' | sed -e '/^New byte order:/d' > "${TMPLOG}"
     if ${comparetool} "${fn}.parsed" "${TMPLOG}"; then
 	: "no differences detected"
     else

--- a/test/swap-byte-order.sh
+++ b/test/swap-byte-order.sh
@@ -3,6 +3,9 @@
 srcdir="${srcdir:-.}"
 TMPLOG="$(mktemp)"
 trap 'rm -f "${TMPLOG}"' 0
+
+. ${srcdir}/inc-comparetool.sh
+
 # Ensure that names are untranslated
 LANG=
 LANGUAGE=
@@ -10,7 +13,9 @@ LC_ALL=C
 export LANG LANGUAGE LC_ALL
 for fn in "${srcdir}"/testdata/*.jpg ; do
     ./test-parse --swap-byte-order "${fn}" | sed -e '/^New byte order:/d' > "${TMPLOG}"
-    if ! diff "${fn}".parsed "${TMPLOG}"; then
+    if ${comparetool} "${fn}.parsed" "${TMPLOG}"; then
+	: "no differences detected"
+    else
         echo Error parsing "$fn"
         exit 1
     fi


### PR DESCRIPTION
I wanted to help a bit with Windows builds of libexif using mingw to cross-compile for Windows on my Linux system, and Wine to run the tests.

However, these tests failed gloriously when run in wine:

```
FAIL: parse-regression.sh
FAIL: swap-byte-order.sh
FAIL: extract-parse.sh
```

This is caused by the `test-parse` program printing CRLF line endings, which will register as being different when compared to the known good content from a text file created on Linux.

So this removes the CR characters for these tests using `tr -d '\015'` in the hope that this will not cause issues with a `diff` or `cmp` or `sed` utility on a build system using CRLF line ending conventions (e.g. msys). If that happens, I have two more complex solutions ready, but I would like to try this much simpler approach first and keep the buildsystem and test suite less complex.

I am filing this as a pull request mainly to have the automatic builds run over the changes them before merging them. I plan to merge this PR as soon as the automatic builds have succeeded.