### PR TITLE
Fix and avoid more warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,6 +147,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([
 	  ],[
 	    double s = sqrt(0);
 	    double p = pow(s,s);
+	    (void) p;
 	  ])],
 	[AC_MSG_RESULT([yes])], [
 	AC_MSG_RESULT([no])
@@ -157,6 +158,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([
 		],[
 		  double s = sqrt(0);
 		  double p = pow(s,s);
+		  (void) p;
 		])],
 	[
 		AC_MSG_RESULT([yes])

--- a/libexif/apple/exif-mnote-data-apple.c
+++ b/libexif/apple/exif-mnote-data-apple.c
@@ -261,6 +261,8 @@ exif_mnote_data_apple_get_value(ExifMnoteData *md, unsigned int i, char *val, un
 
 int
 exif_mnote_data_apple_identify(const ExifData *ed, const ExifEntry *e) {
+    (void) ed;
+
     if (e->size < strlen("Apple iOS")+1)
 	return 0;
 

--- a/libexif/apple/exif-mnote-data-apple.h
+++ b/libexif/apple/exif-mnote-data-apple.h
@@ -18,8 +18,8 @@
  * Boston, MA  02110-1301  USA.
  */
 
-#ifndef __MNOTE_APPLE_CONTENT_H__
-#define __MNOTE_APPLE_CONTENT_H__
+#ifndef __EXIF_MNOTE_DATA_APPLE_H__
+#define __EXIF_MNOTE_DATA_APPLE_H__
 
 #include <libexif/exif-byte-order.h>
 #include <libexif/exif-data.h>
@@ -41,4 +41,4 @@ int exif_mnote_data_apple_identify(const ExifData *, const ExifEntry *);
 
 ExifMnoteData *exif_mnote_data_apple_new(ExifMem *);
 
-#endif /* __MNOTE_APPLE_CONTENT_H__ */
+#endif /* __EXIF_MNOTE_DATA_APPLE_H__ */

--- a/libexif/canon/mnote-canon-entry.c
+++ b/libexif/canon/mnote-canon-entry.c
@@ -701,6 +701,7 @@ mnote_canon_entry_get_value (const MnoteCanonEntry *entry, unsigned int t, char 
 	case MNOTE_CANON_TAG_OWNER:
 		CC (entry->components, 32, val, maxlen);
 		/* Fall through; ImageType can have many sizes */
+		/* fall through */
 	case MNOTE_CANON_TAG_IMAGE_TYPE:
 		CF (entry->format, EXIF_FORMAT_ASCII, val, maxlen);
 		strncpy (val, (char *)data, MIN (entry->size, maxlen));

--- a/libexif/exif-data-type.h
+++ b/libexif/exif-data-type.h
@@ -43,4 +43,4 @@ typedef enum {
 }
 #endif /* __cplusplus */
 
-#endif /* __EXIF_TAG_H__ */
+#endif /* __EXIF_DATA_TYPE_H__ */

--- a/libexif/exif-gps-ifd.c
+++ b/libexif/exif-gps-ifd.c
@@ -59,7 +59,7 @@ static const struct ExifGPSIfdTagInfo exif_gps_ifd_tags[] = {
 };
 
 const ExifGPSIfdTagInfo *exif_get_gps_tag_info(ExifTag tag) {
-  int i;
+  size_t i;
   for (i = 0; i < sizeof(exif_gps_ifd_tags) / sizeof(ExifGPSIfdTagInfo); ++i) {
     if (tag==exif_gps_ifd_tags[i].tag)
       return &exif_gps_ifd_tags[i];

--- a/libexif/exif-gps-ifd.c
+++ b/libexif/exif-gps-ifd.c
@@ -23,7 +23,7 @@
 #include <stddef.h>
 #include "exif-gps-ifd.h"
 
-const static struct ExifGPSIfdTagInfo exif_gps_ifd_tags[] = {
+static const struct ExifGPSIfdTagInfo exif_gps_ifd_tags[] = {
 
     {EXIF_TAG_GPS_VERSION_ID, EXIF_FORMAT_BYTE, 4, 4, "\x02\x02\x00\x00"},
     {EXIF_TAG_GPS_LATITUDE_REF, EXIF_FORMAT_ASCII, 0, 0, 0},

--- a/libexif/exif-mnote-data-priv.h
+++ b/libexif/exif-mnote-data-priv.h
@@ -83,4 +83,4 @@ void exif_mnote_data_set_offset     (ExifMnoteData *, unsigned int);
 }
 #endif /* __cplusplus */
 
-#endif /* __EXIF_MNOTE_PRIV_H__ */
+#endif /* __EXIF_MNOTE_DATA_PRIV_H__ */

--- a/libexif/fuji/exif-mnote-data-fuji.h
+++ b/libexif/fuji/exif-mnote-data-fuji.h
@@ -18,8 +18,8 @@
  * Boston, MA  02110-1301  USA.
  */
 
-#ifndef __MNOTE_FUJI_CONTENT_H__
-#define __MNOTE_FUJI_CONTENT_H__
+#ifndef __EXIF_MNOTE_DATA_FUJI_H__
+#define __EXIF_MNOTE_DATA_FUJI_H__
 
 #include <libexif/exif-mnote-data.h>
 #include <libexif/exif-mnote-data-priv.h>
@@ -50,4 +50,4 @@ int exif_mnote_data_fuji_identify (const ExifData *ed, const ExifEntry *e);
 
 ExifMnoteData *exif_mnote_data_fuji_new (ExifMem *);
 
-#endif /* __MNOTE_FUJI_CONTENT_H__ */
+#endif /* __EXIF_MNOTE_DATA_FUJI_H__ */

--- a/libexif/olympus/exif-mnote-data-olympus.c
+++ b/libexif/olympus/exif-mnote-data-olympus.c
@@ -153,6 +153,7 @@ exif_mnote_data_olympus_save (ExifMnoteData *ne,
 		datao += n->offset + 10;
 		/* subtract the size here, so the increment in the next case will not harm us */
 		*buf_size -= 8 + 2;
+		/* fall through */
 	/* Fall through to nikonV2 handler */
 	case nikonV2: 
 	/* Write out V0 files in V2 format */

--- a/libexif/olympus/exif-mnote-data-olympus.h
+++ b/libexif/olympus/exif-mnote-data-olympus.h
@@ -18,8 +18,8 @@
  * Boston, MA  02110-1301  USA.
  */
 
-#ifndef __MNOTE_OLYMPUS_CONTENT_H__
-#define __MNOTE_OLYMPUS_CONTENT_H__
+#ifndef __EXIF_MNOTE_DATA_OLYMPUS_H__
+#define __EXIF_MNOTE_DATA_OLYMPUS_H__
 
 #include <libexif/exif-mnote-data-priv.h>
 #include <libexif/olympus/mnote-olympus-entry.h>
@@ -64,4 +64,4 @@ int exif_mnote_data_olympus_identify (const ExifData *ed, const ExifEntry *e);
 
 ExifMnoteData *exif_mnote_data_olympus_new (ExifMem *);
 
-#endif /* __MNOTE_OLYMPUS_CONTENT_H__ */
+#endif /* __EXIF_MNOTE_DATA_OLYMPUS_H__ */

--- a/libexif/olympus/mnote-olympus-entry.c
+++ b/libexif/olympus/mnote-olympus-entry.c
@@ -462,7 +462,8 @@ mnote_olympus_entry_get_value (MnoteOlympusEntry *entry, char *v, unsigned int m
 			}
 			break;
 		}
-		/* fall through to handle SHORT version of this tag */
+		/* to handle SHORT version of this tag, */
+		/* fall through */
 	case MNOTE_NIKON_TAG_LENSTYPE:
 	case MNOTE_NIKON_TAG_FLASHUSED:
 	case MNOTE_NIKON1_TAG_QUALITY:
@@ -760,6 +761,7 @@ mnote_olympus_entry_get_value (MnoteOlympusEntry *entry, char *v, unsigned int m
 	case MNOTE_NIKON_TAG_IMAGEBOUNDARY:
 		CC (entry->components, 4, v, maxlen);
 		/* Fall through to COLORMATRIX */
+		/* fall through */
 	case MNOTE_OLYMPUS_TAG_COLORMATRIX:
 		CF (entry->format, EXIF_FORMAT_SHORT, v, maxlen);
 		if (entry->tag == MNOTE_OLYMPUS_TAG_COLORMATRIX)
@@ -776,6 +778,7 @@ mnote_olympus_entry_get_value (MnoteOlympusEntry *entry, char *v, unsigned int m
 	case MNOTE_OLYMPUS_TAG_FOCALPLANEDIAGONAL:
 		CF (entry->format, EXIF_FORMAT_RATIONAL, v, maxlen);
 		/* Fall through to default handler for display */
+		/* fall through */
 	default:
 		switch (entry->format) {
 		case EXIF_FORMAT_ASCII:

--- a/test/test-fuzzer.c
+++ b/test/test-fuzzer.c
@@ -64,7 +64,7 @@ void content_foreach_func(ExifEntry *entry, void *UNUSED(callback_data))
 void data_foreach_func(ExifContent *content, void *callback_data);
 void data_foreach_func(ExifContent *content, void *callback_data)
 {
-	printf("  Content %p: ifd=%d\n", content, exif_content_get_ifd(content));
+	printf("  Content %p: ifd=%d\n", (void *)content, exif_content_get_ifd(content));
 	exif_content_foreach_entry(content, content_foreach_func, callback_data);
 }
 static int

--- a/test/test-gps.c
+++ b/test/test-gps.c
@@ -113,7 +113,7 @@ static int check_entry_format(ExifEntry *e)
 int
 main ()
 {
-	int i;
+	size_t i;
 	ExifData *data = NULL;
 	ExifEntry *e = NULL;
 


### PR DESCRIPTION
This series fixes most compile warnings for clang and gcc, so that you can eventually build with `-Werror`:

    export CFLAGS="-std=c90 -pedantic -Wall -Wextra -Wno-overlength-strings -Wno-switch -Werror -D_XOPEN_SOURCE=500 -D_POSIX_C_SOURCE=1"
    ./configure
    make all check

This works with both `CC=clang` (clang 12.0.1) and `CC=gcc` (11.2.1) on Fedora 34, and with clang 11.0.1 on FreeBSD.

  * The `-Wno-overlength-strings` ignores the C90 constraint for string lengths of 509 characters/bytes.

  * The `-Wno-switch` ignores the weird double use of values in the `ExifTag` enum together with the `#define EXIF_TAG_GPS_*` macros in a switch statement.

  * The `-D` macro definitions are required for compiling against glibc.
