### PR TITLE
Updated exif_tag_exif_version to 0232 in exif_entry_initialize, fix #89

### DIFF
--- a/libexif/exif-entry.c
+++ b/libexif/exif-entry.c
@@ -1816,14 +1816,14 @@ exif_entry_initialize (ExifEntry *e, ExifTag tag)
                 memcpy (e->data, "0100", 4);
                 break;
 
-        /* UNDEFINED, 4 components, default 48 50 49 48 */
+        /* UNDEFINED, 4 components, default 48 50 51 50 */
         case EXIF_TAG_EXIF_VERSION:
                 e->components = 4;
                 e->format = EXIF_FORMAT_UNDEFINED;
                 e->size = exif_format_get_size (e->format) * e->components;
                 e->data = exif_entry_alloc (e, e->size);
                 if (!e->data) { clear_entry(e); break; }
-                memcpy (e->data, "0210", 4);
+                memcpy (e->data, "0232", 4);
                 break;
 
         /* UNDEFINED, 4 components, default 1 2 3 0 */


### PR DESCRIPTION
`exif_entry_initialize` was setting `EXIF_TAG_EXIF_VERSION` to 0210. But in [libexif/exif-tag.h](https://github.com/libexif/libexif/blob/master/libexif/exif-tag.h) there are tags that were added in exif version 2.31 and 2.32, like OffsetTime and CompositeImage. This was also pointed out in issue #89

This pull request updates it to set `EXIF_TAG_EXIF_VERSION` to 0232.

The function is used in `exif_content_fix`, which is used by `exif_data_fix`, used in a. o. in [contrib/examples/write-exif.c](https://github.com/libexif/libexif/blob/master/contrib/examples/write-exif.c).
This fix may prevent warnings on other exif readers encountering tags which are not in exif 2.1.

Resources:
- [Official English translation of Cipa EXIF 2.32 standard](https://www.cipa.jp/std/documents/download_e.html?DC-008-Translation-2019-E), page 3, revision history