### PR TITLE
Set permissions to github workflows

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,7 @@
 name: CIFuzz
 on: [pull_request]
+permissions:
+  contents: read
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,9 @@ on:
     branches: [ "master" ]
   schedule:
     - cron: '35 14 * * 1'
+    
+permissions:
+  contents: read
 
 jobs:
   analyze:
@@ -26,7 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
       security-events: write
 
     strategy:


### PR DESCRIPTION
Closes #98 

### Changes

- set permissions to cifuzz.yml. Example run: https://github.com/joycebrum/libexif/actions/runs/4326593304
- set permissions to codeql.yml. Example run: https://github.com/joycebrum/libexif/actions/runs/4326560010