### PR TITLE
mnotes: make sure passed data isnt NULL before loading

### DIFF
--- a/libexif/canon/exif-mnote-data-canon.c
+++ b/libexif/canon/exif-mnote-data-canon.c
@@ -209,6 +209,8 @@ exif_mnote_data_canon_load (ExifMnoteData *ne,
 	size_t i, tcount, o, datao;
 	long failsafe_size = 0;
 
+	if (n == NULL) return;
+
 	if (!n || !buf || !buf_size) {
 		exif_log (ne->log, EXIF_LOG_CODE_CORRUPT_DATA,
 			  "ExifMnoteCanon", "Short MakerNote");

--- a/libexif/fuji/exif-mnote-data-fuji.c
+++ b/libexif/fuji/exif-mnote-data-fuji.c
@@ -158,6 +158,8 @@ exif_mnote_data_fuji_load (ExifMnoteData *en,
 	ExifLong c;
 	size_t i, tcount, o, datao;
 
+	if (n == NULL) return;
+
 	if (!n || !buf || !buf_size) {
 		exif_log (en->log, EXIF_LOG_CODE_CORRUPT_DATA,
 			  "ExifMnoteDataFuji", "Short MakerNote");

--- a/libexif/olympus/exif-mnote-data-olympus.c
+++ b/libexif/olympus/exif-mnote-data-olympus.c
@@ -242,6 +242,8 @@ exif_mnote_data_olympus_load (ExifMnoteData *en,
 	ExifShort c;
 	size_t i, tcount, o, o2, datao = 6, base = 0;
 
+	if (n == NULL) return;
+
 	if (!n || !buf || !buf_size) {
 		exif_log (en->log, EXIF_LOG_CODE_CORRUPT_DATA,
 			  "ExifMnoteDataOlympus", "Short MakerNote");

--- a/libexif/pentax/exif-mnote-data-pentax.c
+++ b/libexif/pentax/exif-mnote-data-pentax.c
@@ -220,6 +220,8 @@ exif_mnote_data_pentax_load (ExifMnoteData *en,
 	size_t i, tcount, o, datao, base = 0;
 	ExifShort c;
 
+	if (n == NULL) return;
+
 	if (!n || !buf || !buf_size) {
 		exif_log (en->log, EXIF_LOG_CODE_CORRUPT_DATA,
 			  "ExifMnoteDataPentax", "Short MakerNote");


### PR DESCRIPTION
Fixes NPDs found by scan-build.

Example:
![image](https://user-images.githubusercontent.com/24401303/233735447-6f5689b5-f80c-47ea-9017-a26a73d0b5bf.png)
