### PR TITLE
Add SPDX license tags to some source files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,8 @@
+# Root automake makefile for libexif
+#
+# Copyright (c) 2001-2020 Lutz Mueller <lutz@users.sourceforge.net>, et. al.
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
 SUBDIRS = m4m po libexif test doc binary-dist contrib
 
 EXTRA_DIST = @PACKAGE_TARNAME@.spec README-Win32.txt

--- a/binary-dist/Makefile.am
+++ b/binary-dist/Makefile.am
@@ -1,3 +1,6 @@
+# Copyright (C) 2005 Hans Ulrich Niedermann <gp@n-dimensional.de>
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
 if SHIP_BINARIES
 
 EXTRA_DIST = include bin

--- a/configure.ac
+++ b/configure.ac
@@ -1,3 +1,8 @@
+dnl autoconf configuration for libexif
+dnl
+dnl Copyright (c) 2001-2022 Lutz Mueller <lutz@users.sourceforge.net>, et. al.
+dnl SPDX-License-Identifier: LGPL-2.0-or-later
+
 AC_PREREQ(2.69)
 AC_INIT([EXIF library],
         [0.6.24.1],

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1,5 +1,7 @@
 ########################################################################
 # Conditional rules, depending on tool availability
+# Copyright (C) 2005-2007 Hans Ulrich Niedermann <gp@n-dimensional.de>, et. al.
+# SPDX-License-Identifier: LGPL-2.0-or-later
 ########################################################################
 
 DOXYGEN_FILES =

--- a/libexif-uninstalled.pc.in
+++ b/libexif-uninstalled.pc.in
@@ -1,3 +1,5 @@
+# Copyright (C) 2007 Hans Ulrich Niedermann <hun@n-dimensional.de>
+# SPDX-License-Identifier: LGPL-2.0-or-later
 Name: libexif
 Description: Library for easy access to EXIF data
 Version: @VERSION@

--- a/libexif.pc.in
+++ b/libexif.pc.in
@@ -1,3 +1,5 @@
+# Copyright (C) 2001-2009 Lutz Mueller <lutz.s.mueller@gmail.com>, et. al.
+# SPDX-License-Identifier: LGPL-2.0-or-later
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@

--- a/libexif/Makefile.am
+++ b/libexif/Makefile.am
@@ -1,3 +1,6 @@
+# Copyright (c) 2001-2022 Lutz Mueller <lutz@users.sourceforge.net>, et. al.
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
 EXTRA_DIST =
 lib_LTLIBRARIES =
 noinst_LTLIBRARIES =

--- a/libexif/canon/Makefile-files
+++ b/libexif/canon/Makefile-files
@@ -1,4 +1,6 @@
 # -*- Makefile -*-
+# Copyright (C) 2002-2007 Lutz Mueller <lutz@users.sourceforge.net>, et. al.
+# SPDX-License-Identifier: LGPL-2.0-or-later
 noinst_LTLIBRARIES += libmnote-canon.la
 libmnote_canon_la_SOURCES = \
 	canon/exif-mnote-data-canon.c canon/exif-mnote-data-canon.h \

--- a/libexif/exif-data.h
+++ b/libexif/exif-data.h
@@ -2,8 +2,7 @@
  * \brief Defines the ExifData type and the associated functions.
  */
 /*
- * \author Lutz Mueller <lutz@users.sourceforge.net>
- * \date 2001-2005
+ * Copyright (c) 2001-2008 Lutz Mueller <lutz@users.sourceforge.net>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/libexif/exif-ifd.c
+++ b/libexif/exif-ifd.c
@@ -16,6 +16,8 @@
  * License along with this library; if not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #include <config.h>

--- a/libexif/exif-ifd.h
+++ b/libexif/exif-ifd.h
@@ -16,6 +16,8 @@
  * License along with this library; if not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #ifndef LIBEXIF_EXIF_IFD_H

--- a/libexif/exif-mem.c
+++ b/libexif/exif-mem.c
@@ -1,3 +1,25 @@
+/* exif-mem.c
+ *
+ * Copyright (c) 2004 Lutz Mueller <lutz@users.sourceforge.net>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA  02110-1301  USA.
+ *
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ */
+
 #include <libexif/exif-mem.h>
 
 #include <stdlib.h>

--- a/libexif/exif-mnote-data.c
+++ b/libexif/exif-mnote-data.c
@@ -16,6 +16,8 @@
  * License along with this library; if not, write to the
  * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301  USA.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #include <config.h>

--- a/libexif/exif.h
+++ b/libexif/exif.h
@@ -85,6 +85,9 @@
  * can use libexif without issues if they never share handles.
  *
  */
+/* Copyright (C) 2007-2021 Hans Ulrich Niedermann <gp@n-dimensional.de>
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ */
 
 #ifndef LIBEXIF_EXIF_H
 #define LIBEXIF_EXIF_H

--- a/libexif/fuji/Makefile-files
+++ b/libexif/fuji/Makefile-files
@@ -1,4 +1,6 @@
 # -*- Makefile -*-
+# Copyright (C) 2002-2007 Lutz Mueller <lutz@users.sourceforge.net>, et. al.
+# SPDX-License-Identifier: LGPL-2.0-or-later
 noinst_LTLIBRARIES += libmnote-fuji.la
 libmnote_fuji_la_SOURCES = \
 	fuji/mnote-fuji-entry.c fuji/mnote-fuji-entry.h \

--- a/libexif/olympus/Makefile-files
+++ b/libexif/olympus/Makefile-files
@@ -1,4 +1,6 @@
 # -*- Makefile -*-
+# Copyright (C) 2002-2007 Lutz Mueller <lutz@users.sourceforge.net>, et. al.
+# SPDX-License-Identifier: LGPL-2.0-or-later
 noinst_LTLIBRARIES += libmnote-olympus.la
 libmnote_olympus_la_SOURCES = \
 	olympus/mnote-olympus-entry.c olympus/mnote-olympus-entry.h \

--- a/libexif/pentax/Makefile-files
+++ b/libexif/pentax/Makefile-files
@@ -1,4 +1,6 @@
 # -*- Makefile -*-
+# Copyright (C) 2003-2007 Lutz Mueller <lutz@users.sourceforge.net>, et. al.
+# SPDX-License-Identifier: LGPL-2.0-or-later
 noinst_LTLIBRARIES += libmnote-pentax.la
 libmnote_pentax_la_SOURCES = \
 	pentax/mnote-pentax-entry.c pentax/mnote-pentax-entry.h \

--- a/m4m/Makefile.am
+++ b/m4m/Makefile.am
@@ -1,3 +1,6 @@
+# Copyright (C) 2005 Hans Ulrich Niedermann <gp@n-dimensional.de>, et. al.
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
 EXTRA_DIST = \
 	gp-check-shell-environment.m4 \
 	gp-config-msg.m4 \

--- a/m4m/gp-check-shell-environment.m4
+++ b/m4m/gp-check-shell-environment.m4
@@ -5,6 +5,8 @@ dnl
 dnl If SHOW-LOCALE-VARS is set to [true], print all LC_* and LANG*
 dnl variables at configure time. (WARNING: This is not portable!)
 dnl
+dnl Copyright (C) 2005-2021 Hans Ulrich Niedermann <gp@n-dimensional.de>
+dnl SPDX-License-Identifier: LGPL-2.0-or-later
 dnl
 AC_DEFUN([GP_CHECK_SHELL_ENVIRONMENT],
 [

--- a/m4m/gp-config-msg.m4
+++ b/m4m/gp-config-msg.m4
@@ -1,4 +1,3 @@
-dnl
 dnl GP_CONFIG_INIT
 dnl      use default LHS width (called implicitly if not called explicitly)
 dnl GP_CONFIG_INIT([WIDTH-OF-LHS])
@@ -26,6 +25,8 @@ dnl    [...]
 dnl    AC_OUTPUT
 dnl    GP_CONFIG_OUTPUT
 dnl
+dnl Copyright (C) 2005 Hans Ulrich Niedermann <gp@n-dimensional.de>
+dnl SPDX-License-Identifier: LGPL-2.0-or-later
 dnl
 AC_DEFUN([GP_CONFIG_INIT],
 [dnl

--- a/m4m/gp-documentation.m4
+++ b/m4m/gp-documentation.m4
@@ -4,6 +4,9 @@ dnl
 dnl determines documentation "root directory", i.e. the directory
 dnl where all documentation will be placed in
 dnl
+dnl Copyright (C) 2005-2021 Hans Ulrich Niedermann <gp@n-dimensional.de>
+dnl SPDX-License-Identifier: LGPL-2.0-or-later
+dnl
 
 AC_DEFUN([GP_DOC_GENERAL],[dnl
 AC_MSG_CHECKING([whether to build any docs])

--- a/m4m/gp-gettext-hack.m4
+++ b/m4m/gp-gettext-hack.m4
@@ -19,6 +19,8 @@ dnl
 dnl You can leave out the GP_GETTEXT_HACK parameters if you want to,
 dnl GP_GETTEXT_HACK will try fall back to sensible values in that case:
 dnl
+dnl SPDX-License-Identifier: LGPL-2.0-or-later
+dnl
 
 AC_DEFUN([GP_GETTEXT_HACK],
 [

--- a/po/de.po
+++ b/po/de.po
@@ -2,8 +2,7 @@
 # Copyright:
 # This file is distributed under the same license as the libexif package.
 #
-#   Free Software Foundation, Inc., 2002.
-#   Lutz Mueller <lutz@users.sourceforge.net>, 2002.
+# Copyright (c) 2002 Lutz Mueller <lutz@users.sourceforge.net>
 #   Marcus Meissner <marcus@jet.franken.de>, 2004, 2005, 2006, 2007, 2008, 2009, 2010.
 #   Mario Blättermann <mario.blaettermann@gmail.com>, 2011.
 #   Christian Kirbach <christian.kirbach@gmail.com>, 2011, 2012, 2021.

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,3 +1,6 @@
+# Copyright (C) 2001-2021 Lutz Mueller <lutz@users.sourceforge.net>, et. al.
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
 SUBDIRS = nls
 
 # By default, a few definitions like bindir, srcdir are already set.

--- a/test/inc-comparetool.sh
+++ b/test/inc-comparetool.sh
@@ -3,6 +3,9 @@
 # cmp(1) creates the same exit code as diff in case of files being
 # different or the same, even though the diff(1) output is more
 # informative
+#
+# Copyright (c) 2021 Hans Ulrich Niedermann <gp@n-dimensional.de>
+# SPDX-License-Identifier: LGPL-2.0-or-later
 
 if test "x$DIFF_U" != x && test "x$DIFF_U" != xno
 then

--- a/test/nls/Makefile.am
+++ b/test/nls/Makefile.am
@@ -1,3 +1,6 @@
+# Copyright (C) 2005-2007 Hans Ulrich Niedermann <gp@n-dimensional.de>
+# SPDX-License-Identifier: LGPL-2.0-or-later
+
 nlstestscripts = check-localedir.sh # check-codeset.sh
 
 codeset_tests = test-codeset-default test-codeset-latin1 test-codeset-utf-8

--- a/test/nls/check-codeset.in
+++ b/test/nls/check-codeset.in
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Copyright (C) 2007 Hans Ulrich Niedermann <gp@n-dimensional.de>
+# SPDX-License-Identifier: LGPL-2.0-or-later
 
 # NLS nuisances. (stolen and adapted from configure)
 for as_var in \

--- a/test/nls/check-localedir.in
+++ b/test/nls/check-localedir.in
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Copyright (C) 2005 Hans Ulrich Niedermann <gp@n-dimensional.de>
+# SPDX-License-Identifier: LGPL-2.0-or-later
 
 localedir="@localedir@"
 build_alias="@build_alias@"

--- a/test/nls/check-nls.in
+++ b/test/nls/check-nls.in
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Copyright (C) 2005 Hans Ulrich Niedermann <gp@n-dimensional.de>
+# SPDX-License-Identifier: LGPL-2.0-or-later
 
 top_builddir="@top_builddir@"
 localedir="@localedir@"

--- a/test/nls/print-localedir.c
+++ b/test/nls/print-localedir.c
@@ -1,3 +1,7 @@
+/* Copyright (C) 2005-2007 Hans Ulrich Niedermann <gp@n-dimensional.de>
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ */
+
 #include "config.h"
 #include "libexif/i18n.h"
 

--- a/test/nls/test-codeset.c
+++ b/test/nls/test-codeset.c
@@ -1,3 +1,7 @@
+/* Copyright (C) 2005 Hans Ulrich Niedermann <gp@n-dimensional.de>
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/test/nls/test-nls.c
+++ b/test/nls/test-nls.c
@@ -1,3 +1,7 @@
+/* Copyright (C) 2005 Hans Ulrich Niedermann <gp@n-dimensional.de>, et. al.
+ * SPDX-License-Identifier: LGPL-2.0-or-later
+ */
+
 #include "config.h"
 
 #include "i18n.h"


### PR DESCRIPTION
This set of files was originally created by three of the primary authors
of libexif, Hans Ulrich Niedermann, Lutz Mueller and Marcus Meissner.

This is the first commit to add SPDX tags to libexif source files with a goal
of adding them to all of them and achieve REUSE compliance to make it easier
for developers to check license compliance when using libexif.