### PR TITLE
Add a sanity check to SRATIONAL denominator values before calling abs()

### DIFF
--- a/libexif/exif-entry.c
+++ b/libexif/exif-entry.c
@@ -573,7 +573,7 @@ exif_entry_format_value(ExifEntry *e, char *val, size_t maxlen)
 			}
 			v_srat = exif_get_srational (
 				e->data + 8 * i, o);
-			if (v_srat.denominator) {
+			if (v_srat.denominator && v_srat.denominator > INT32_MIN) {
 				int decimals = (int)(log10(abs(v_srat.denominator))-0.08+1.0);
 				snprintf (val+len, maxlen-len, "%2.*f",
 					  decimals,


### PR DESCRIPTION
Hello, this is a possible fix to prevent a call to `abs(INT32_MIN)` and therefore prevent an integer overflow.

> exif-entry.c:577:36: runtime error: negation of -2147483648 cannot be represented in type 'int'

This problem was found via fuzz testing and I'd be happy to provide sample EXIF data that triggers it if required.