### PR TITLE
exif-data: skip invalid tags rather than abort when not recursing

### DIFF
--- a/libexif/exif-data.c
+++ b/libexif/exif-data.c
@@ -456,7 +456,9 @@ exif_data_load_data_content (ExifData *data, ExifIfd ifd,
 			if (o >= ds) {
 				exif_log (data->priv->log, EXIF_LOG_CODE_CORRUPT_DATA, "ExifData",
 					  "Tag data past end of buffer (%u > %u)", offset+2, ds);
-				return;
+				if (recursion_cost > 0)
+					return;
+				break;
 			}
 			/* FIXME: IFD_POINTER tags aren't marked as being in a
 			 * specific IFD, so exif_tag_get_name_in_ifd won't work


### PR DESCRIPTION
Commit https://github.com/libexif/libexif/commit/cdf1e32cb71c22c3df5d806d74384b3189008a47 fixed [a vulnerability](https://issues.oss-fuzz.com/issues/42481167) by aborting early, however my understanding of the problem was that it could occur only when parsing nested directories.

By aborting early, EXIF metadata from many Samsung devices could no longer be parsed as these often contain invalid thumbnail offsets/lengths.

Sample images that fail (I originally mistook this as a tag-ordering problem):

- https://github.com/libvips/libvips/discussions/4073
- https://github.com/lovell/sharp/issues/4280

With this change, the vulnerability remains fixed and EXIF metadata from Samsung devices can be parsed.