### PR TITLE
exif-tag: fix const-qualifier warning in exif_tag_table_first

### DIFF
--- a/libexif/exif-tag.c
+++ b/libexif/exif-tag.c
@@ -1015,7 +1015,7 @@ static int
 exif_tag_table_first(ExifTag tag)
 {
 	int i;
-	struct TagEntry *entry = bsearch(&tag, ExifTagTable,
+	const struct TagEntry *entry = bsearch(&tag, ExifTagTable,
 		exif_tag_table_count()-1, sizeof(struct TagEntry), match_tag);
 	if (!entry)
 		return -1;	/* Not found */


### PR DESCRIPTION
bsearch() searches a const array (ExifTagTable), so the result pointer must be declared const to avoid discarding the qualifier.