### PR TITLE
[fix] Allow building on Windows with MSVC without ssize_t error

### DIFF
--- a/libexif/exif-loader.c
+++ b/libexif/exif-loader.c
@@ -30,6 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <stddef.h>
 
 #undef JPEG_MARKER_DCT
 #define JPEG_MARKER_DCT  0xc0
@@ -308,7 +309,7 @@ begin:
 		default:
 			switch (eld->b[i]) {
 			case JPEG_MARKER_APP1:
-			  if (!memcmp (eld->b + i + 3, ExifHeader, MIN((ssize_t)(sizeof(ExifHeader)), MAX(0, ((ssize_t)(sizeof(eld->b))) - ((ssize_t)i) - 3)))) {
+			  if (!memcmp (eld->b + i + 3, ExifHeader, MIN((ptrdiff_t)(sizeof(ExifHeader)), MAX(0, ((ptrdiff_t)(sizeof(eld->b))) - ((ptrdiff_t)i) - 3)))) {
 					eld->data_format = EL_DATA_FORMAT_EXIF;
 				} else {
 					eld->data_format = EL_DATA_FORMAT_JPEG; /* Probably JFIF - keep searching for APP1 EXIF*/


### PR DESCRIPTION
Greetings!

Around 5 years ago we packaged for the first time libexif in [Conan.io](https://conan.io/center/recipes/libexif?version=0.6.24) via PR https://github.com/conan-io/conan-center-index/pull/6846. Still in that occasion was noted an error when trying to build libexif 0.6.23 using Visual Studio on Windows:

```
exif-loader.c
C:/j/w/buildsinglereference@7/.conan/data/libexif/0.6.23/_/_/build/f42ebec2d0ee7d5c41713cd8eee15cf988b0d202/source_subfolder/libexif/exif-loader.c(305): error C2065: 'ssize_t': undeclared identifier
C:/j/w/buildsinglereference@7/.conan/data/libexif/0.6.23/_/_/build/f42ebec2d0ee7d5c41713cd8eee15cf988b0d202/source_subfolder/libexif/exif-loader.c(305): error C2064: term does not evaluate to a function taking 19 arguments
C:/j/w/buildsinglereference@7/.conan/data/libexif/0.6.23/_/_/build/f42ebec2d0ee7d5c41713cd8eee15cf988b0d202/source_subfolder/libexif/exif-loader.c(305): warning C4020: 'memcmp': too many actual parameters
C:/j/w/buildsinglereference@7/.conan/data/libexif/0.6.23/_/_/build/f42ebec2d0ee7d5c41713cd8eee15cf988b0d202/source_subfolder/libexif/exif-loader.c(305): error C2146: syntax error: missing ')' before identifier 'i'
C:/j/w/buildsinglereference@7/.conan/data/libexif/0.6.23/_/_/build/f42ebec2d0ee7d5c41713cd8eee15cf988b0d202/source_subfolder/libexif/exif-loader.c(305): error C2059: syntax error: ')'
C:/j/w/buildsinglereference@7/.conan/data/libexif/0.6.23/_/_/build/f42ebec2d0ee7d5c41713cd8eee15cf988b0d202/source_subfolder/libexif/exif-loader.c(307): error C2181: illegal else without matching if
C:/j/w/buildsinglereference@7/.conan/data/libexif/0.6.23/_/_/build/f42ebec2d0ee7d5c41713cd8eee15cf988b0d202/source_subfolder/libexif/exif-loader.c(331): error C2048: more than one default
C:/j/w/buildsinglereference@7/.conan/data/libexif/0.6.23/_/_/build/f42ebec2d0ee7d5c41713cd8eee15cf988b0d202/source_subfolder/libexif/exif-loader.c(347): error C2143: syntax error: missing '{' before '->'
C:/j/w/buildsinglereference@7/.conan/data/libexif/0.6.23/_/_/build/f42ebec2d0ee7d5c41713cd8eee15cf988b0d202/source_subfolder/libexif/exif-loader.c(347): error C2059: syntax error: '->'
C:/j/w/buildsinglereference@7/.conan/data/libexif/0.6.23/_/_/build/f42ebec2d0ee7d5c41713cd8eee15cf988b0d202/source_subfolder/libexif/exif-loader.c(348): error C2059: syntax error: 'goto'
C:/j/w/buildsinglereference@7/.conan/data/libexif/0.6.23/_/_/build/f42ebec2d0ee7d5c41713cd8eee15cf988b0d202/source_subfolder/libexif/exif-loader.c(349): error C2059: syntax error: '}'
make[2]: *** [Makefile:764: exif-loader.lo] Error 1
```

Full build log: https://c3i.jfrog.io/c3i/misc/logs/pr/6846/10-configs/windows-visual_studio/libexif/0.6.23//f42ebec2d0ee7d5c41713cd8eee15cf988b0d202-build.txt

That error occurred because the type `ssize_t` is POSIX, and a result, Visual Studio does not recognize if by default. 

References about `ssize_t` specification:
* https://man.archlinux.org/man/ssize_t.3type.en
* https://man7.org/linux/man-pages/man3/size_t.3type.html

Still in that PR, we started to use a custom patch, by including [BaseTsd.h](https://learn.microsoft.com/en-us/windows/win32/winprog/windows-data-types), which contains `SSIZE_T`, a signed version of `SIZE_T`.

Recently, we received a new PR to publish libexif 0.2.26: https://github.com/conan-io/conan-center-index/pull/30393 and during the review, was possible to see the same scenario again when building on Windows without that patch. As a try of cleaning the PR in Conan side, I prepared this new and better patch, as a suggestion of a final fix for Window with Visual Studio.

Locally, I built version 0.2.26 **without** the patch, and obtained the same error:

```
libtool: compile:  /c/users/uilia/.conan2/p/b/libex8434f7ff32429/b/src/compile cl -nologo -std:c11 -DHAVE_CONFIG_H -I. -I/c/users/uilia/.conan2/p/b/libex8434f7ff32429/b/src/libexif -I.. -DNDEBUG -DGETTEXT_PACKAGE=\"libexif-12\" -DLOCALEDIR=\"//share/locale\" -I/c/users/uilia/.conan2/p/b/libex8434f7ff32429/b/src -I.. -DNDEBUG -MD -O2 -Ob2 -FS -c -showIncludes /c/users/uilia/.conan2/p/b/libex8434f7ff32429/b/src/libexif/exif-loader.c -o exif-loader.obj
exif-loader.c
C:\users\uilia\.conan2\p\b\libex8434f7ff32429\b\src\libexif\exif-loader.c(311): error C2065: 'ssize_t': undeclared identifier
C:\users\uilia\.conan2\p\b\libex8434f7ff32429\b\src\libexif\exif-loader.c(311): error C2064: term does not evaluate to a function taking 0 arguments
C:\users\uilia\.conan2\p\b\libex8434f7ff32429\b\src\libexif\exif-loader.c(311): error C2197: 'int memcmp(const void *,const void *,size_t)': too many arguments for call
C:\users\uilia\.conan2\p\b\libex8434f7ff32429\b\src\libexif\exif-loader.c(311): error C2146: syntax error: missing ')' before identifier 'i'
C:\users\uilia\.conan2\p\b\libex8434f7ff32429\b\src\libexif\exif-loader.c(311): error C2059: syntax error: ')'
C:\users\uilia\.conan2\p\b\libex8434f7ff32429\b\src\libexif\exif-loader.c(313): error C2181: illegal else without matching if
C:\users\uilia\.conan2\p\b\libex8434f7ff32429\b\src\libexif\exif-loader.c(339): error C2048: more than one default
C:\users\uilia\.conan2\p\b\libex8434f7ff32429\b\src\libexif\exif-loader.c(355): error C2143: syntax error: missing '{' before '->'
C:\users\uilia\.conan2\p\b\libex8434f7ff32429\b\src\libexif\exif-loader.c(355): error C2059: syntax error: '->'
C:\users\uilia\.conan2\p\b\libex8434f7ff32429\b\src\libexif\exif-loader.c(356): error C2059: syntax error: 'goto'
C:\users\uilia\.conan2\p\b\libex8434f7ff32429\b\src\libexif\exif-loader.c(357): error C2059: syntax error: '}'
```

Full build log: [libexif-0.6.26-windows-amd64-msvc194-release-static.log](https://github.com/user-attachments/files/29001223/libexif-0.6.26-windows-amd64-msvc194-release-static.log)

Then, after applying this patch, I can build with **no** errors: [libexif-0.6.26-windows-amd64-msvc194-release-static-patched.log](https://github.com/user-attachments/files/29001242/libexif-0.6.26-windows-amd64-msvc194-release-static-patched.log)

This patch is difference from the previous, but much better:

As `size_t` could overflow, then a signed size_t (ssize_t) is a good option for that diff. Unlike `ssize_t`, the `ptrdiff_t` is C99 standard and a signed counterpart of size_t. In mainstream platforms, like x86, ARM, ..., they both are the same type anyway.

References:
* https://en.cppreference.com/c/types/ptrdiff_t
* https://man7.org/linux/man-pages/man3/ptrdiff_t.3type.html
* https://learn.microsoft.com/en-us/cpp/standard-library/cstddef?view=msvc-170

Regards! 