### PR TITLE
exif-data: don't decrement count when removing entry fails

### DIFF
--- a/libexif/exif-data.c
+++ b/libexif/exif-data.c
@@ -1339,7 +1339,7 @@ fix_func (ExifContent *c, void *UNUSED(data))
 				if (cnt == c->count) {
 					/* safety net */
 					exif_log (c->parent->priv->log, EXIF_LOG_CODE_DEBUG, "exif-data",
-					"failed to remove last entry from entries.");
+						  "failed to remove entry from entries.");
 					break;
 				}
 			}

--- a/libexif/exif-data.c
+++ b/libexif/exif-data.c
@@ -1340,7 +1340,7 @@ fix_func (ExifContent *c, void *UNUSED(data))
 					/* safety net */
 					exif_log (c->parent->priv->log, EXIF_LOG_CODE_DEBUG, "exif-data",
 					"failed to remove last entry from entries.");
-					c->count--;
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
The fallback c->count-- in fix_func() was intended to avoid an infinite loop if exif_content_remove_entry() failed. However, removal can fail due to an allocation failure before changing the content.

In that case the entry remains owned by the ExifContent, but decrementing c->count makes it unreachable and leaks it. Stop attempting to remove entries when removal fails and leave the content state unchanged.

This was discovered by libvips in https://github.com/libvips/libvips/pull/5129, which adds a fuzzer that deterministically injects allocation failures.