### PR TITLE
Log some more EXIF_LOG_NO_MEMORY on OOM

### DIFF
--- a/libexif/exif-content.c
+++ b/libexif/exif-content.c
@@ -141,6 +141,7 @@ void
 exif_content_add_entry (ExifContent *c, ExifEntry *entry)
 {
 	ExifEntry **entries;
+	unsigned int s;
 	if (!c || !c->priv || !entry || entry->parent) return;
 
 	/* One tag can only be added once to an IFD. */
@@ -152,9 +153,12 @@ exif_content_add_entry (ExifContent *c, ExifEntry *entry)
 		return;
 	}
 
-	entries = exif_mem_realloc (c->priv->mem,
-		c->entries, sizeof (ExifEntry*) * (c->count + 1));
-	if (!entries) return;
+	s = sizeof (ExifEntry*) * (c->count + 1);
+	entries = exif_mem_realloc (c->priv->mem, c->entries, s);
+	if (!entries) {
+		EXIF_LOG_NO_MEMORY (c->priv->log, "ExifContent", s);
+		return;
+	}
 	entry->parent = c;
 	entries[c->count++] = entry;
 	c->entries = entries;
@@ -180,9 +184,10 @@ exif_content_remove_entry (ExifContent *c, ExifEntry *e)
 	/* Remove the entry */
 	temp = c->entries[c->count-1];
 	if (c->count > 1) {
-		t = exif_mem_realloc (c->priv->mem, c->entries,
-					sizeof(ExifEntry*) * (c->count - 1));
+		const unsigned int s = sizeof(ExifEntry*) * (c->count - 1);
+		t = exif_mem_realloc (c->priv->mem, c->entries, s);
 		if (!t) {
+			EXIF_LOG_NO_MEMORY (c->priv->log, "ExifContent", s);
 			return;
 		}
 		c->entries = t;

--- a/libexif/exif-entry.c
+++ b/libexif/exif-entry.c
@@ -1394,14 +1394,20 @@ exif_entry_get_value (ExifEntry *e, char *val, unsigned int maxlen)
 	case EXIF_TAG_XP_SUBJECT:
 	{
 		unsigned char *utf16;
+		unsigned int s;
 
 		/* Sanity check the size to prevent overflow. Note EXIF files are 64kb at most. */
 		if (e->size >= 65536 - sizeof(uint16_t)*2) break;
 
 		/* The tag may not be U+0000-terminated , so make a local
 		   U+0000-terminated copy before converting it */
-		utf16 = exif_mem_alloc (e->priv->mem, e->size+sizeof(uint16_t)+1);
-		if (!utf16) break;
+		s = e->size+sizeof(uint16_t)+1;
+		utf16 = exif_mem_alloc (e->priv->mem, s);
+		if (!utf16) {
+			exif_entry_log (e, EXIF_LOG_CODE_NO_MEMORY,
+				"Could not allocate %lu byte(s).", (unsigned long)s);
+			break;
+		}
 		memcpy(utf16, e->data, e->size);
 
 		/* NUL terminate the string. If the size is odd (which isn't possible

--- a/libexif/exif-mnote-data.c
+++ b/libexif/exif-mnote-data.c
@@ -39,7 +39,10 @@ exif_mnote_data_construct (ExifMnoteData *d, ExifMem *mem)
 	if (!d || !mem) return;
 	if (d->priv) return;
 	d->priv = exif_mem_alloc (mem, sizeof (ExifMnoteDataPriv));
-	if (!d->priv) return;
+	if (!d->priv) {
+		EXIF_LOG_NO_MEMORY (d->log, "ExifMnoteData", sizeof (ExifMnoteDataPriv));
+		return;
+	}
 
 	d->priv->ref_count = 1;
 

--- a/libexif/exif.h
+++ b/libexif/exif.h
@@ -70,6 +70,13 @@
  * Libexif by default relies on the calloc(3), realloc(3), and free(3)
  * functions, but the libexif user can tell libexif to use their
  * special memory management functions at runtime.
+ *
+ * When memory allocation failures occur within libexif and there is no way
+ * to notify the caller (such as by returning a NULL pointer), a message is
+ * logged using the #ExifLog interface with the #EXIF_LOG_CODE_NO_MEMORY
+ * code.  This failure may have left libexif data structures in an
+ * inconsistent state, so the application should refrain from using existing
+ * libexif structures after such a log call has been made.
  * 
  * \section thread_safety Thread Safety
  * 
@@ -85,7 +92,8 @@
  * can use libexif without issues if they never share handles.
  *
  */
-/* Copyright (C) 2007-2021 Hans Ulrich Niedermann <gp@n-dimensional.de>
+/* Copyright (C) 2007-2026 Hans Ulrich Niedermann <gp@n-dimensional.de>,
+ * et. al.
  * SPDX-License-Identifier: LGPL-2.0-or-later
  */
 

--- a/libexif/fuji/exif-mnote-data-fuji.c
+++ b/libexif/fuji/exif-mnote-data-fuji.c
@@ -97,6 +97,7 @@ exif_mnote_data_fuji_save (ExifMnoteData *ne, unsigned char **buf,
 	*buf_size = 8 + 4 + 2 + n->count * 12 + 4;
 	*buf = exif_mem_alloc (ne->mem, *buf_size);
 	if (!*buf) {
+		EXIF_LOG_NO_MEMORY (ne->log, "ExifMnoteDataFuji", *buf_size);
 		*buf_size = 0;
 		return;
 	}
@@ -133,6 +134,7 @@ exif_mnote_data_fuji_save (ExifMnoteData *ne, unsigned char **buf,
 			if (s & 1) ts += 1;
 			t = exif_mem_realloc (ne->mem, *buf, ts);
 			if (!t) {
+				EXIF_LOG_NO_MEMORY (ne->log, "ExifMnoteDataFuji", ts);
 				return;
 			}
 			*buf = t;


### PR DESCRIPTION
Some internal memory calls were being made whose failures were not
logged and whose callers were not notified. Log these failures so that
the application can take an appropriate response on OOM, like
terminating the program (which is what the exif front-end does).
Add to the documentation a warning against continuing after such a
failure.

Closes #269