### PR TITLE
Limit aggregate MakerNote allocations

### DIFF
--- a/libexif/canon/exif-mnote-data-canon.c
+++ b/libexif/canon/exif-mnote-data-canon.c
@@ -210,7 +210,7 @@ exif_mnote_data_canon_load (ExifMnoteData *ne,
 {
 	ExifMnoteDataCanon *n = (ExifMnoteDataCanon *) ne;
 	ExifShort c;
-	size_t i, tcount, o, datao;
+	size_t i, tcount, o, datao, copied_size = 0;
 	long failsafe_size = 0;
 
 	if (!n) return;
@@ -303,6 +303,12 @@ exif_mnote_data_canon_load (ExifMnoteData *ne,
 					(unsigned)(dataofs + s), buf_size);
 				continue;
 			}
+			if (s > buf_size - copied_size) {
+				exif_log (ne->log, EXIF_LOG_CODE_CORRUPT_DATA,
+					"ExifMnoteCanon",
+					"MakerNote data exceeds input size");
+				break;
+			}
 
 			n->entries[tcount].data = exif_mem_alloc (ne->mem, s);
 			if (!n->entries[tcount].data) {
@@ -310,6 +316,7 @@ exif_mnote_data_canon_load (ExifMnoteData *ne,
 				continue;
 			}
 			memcpy (n->entries[tcount].data, buf + dataofs, s);
+			copied_size += s;
 		}
 
 		/* Track the size of decoded tag data. A malicious file could

--- a/libexif/fuji/exif-mnote-data-fuji.c
+++ b/libexif/fuji/exif-mnote-data-fuji.c
@@ -160,7 +160,7 @@ exif_mnote_data_fuji_load (ExifMnoteData *en,
 {
 	ExifMnoteDataFuji *n = (ExifMnoteDataFuji*) en;
 	ExifLong c;
-	size_t i, tcount, o, datao;
+	size_t i, tcount, o, datao, copied_size = 0;
 
 	if (!n) return;
 
@@ -255,6 +255,12 @@ exif_mnote_data_fuji_load (ExifMnoteData *en,
 					  "buffer (%u >= %u)", (unsigned)(dataofs + s), buf_size);
 				continue;
 			}
+			if (s > buf_size - copied_size) {
+				exif_log (en->log, EXIF_LOG_CODE_CORRUPT_DATA,
+					  "ExifMnoteDataFuji",
+					  "MakerNote data exceeds input size");
+				break;
+			}
 
 			n->entries[tcount].data = exif_mem_alloc (en->mem, s);
 			if (!n->entries[tcount].data) {
@@ -262,6 +268,7 @@ exif_mnote_data_fuji_load (ExifMnoteData *en,
 				continue;
 			}
 			memcpy (n->entries[tcount].data, buf + dataofs, s);
+			copied_size += s;
 		}
 
 		/* Tag was successfully parsed */

--- a/libexif/olympus/exif-mnote-data-olympus.c
+++ b/libexif/olympus/exif-mnote-data-olympus.c
@@ -242,7 +242,7 @@ exif_mnote_data_olympus_load (ExifMnoteData *en,
 {
 	ExifMnoteDataOlympus *n = (ExifMnoteDataOlympus *) en;
 	ExifShort c;
-	size_t i, tcount, o, o2, datao = 6, base = 0;
+	size_t i, tcount, o, o2, datao = 6, base = 0, copied_size = 0;
 
 	if (!n) return;
 
@@ -502,6 +502,12 @@ exif_mnote_data_olympus_load (ExifMnoteData *en,
 					  (unsigned)(dataofs + s), buf_size);
 				continue;
 			}
+			if (s > buf_size - copied_size) {
+				exif_log (en->log, EXIF_LOG_CODE_CORRUPT_DATA,
+						  "ExifMnoteOlympus",
+						  "MakerNote data exceeds input size");
+				break;
+			}
 
 			n->entries[tcount].data = exif_mem_alloc (en->mem, s);
 			if (!n->entries[tcount].data) {
@@ -509,6 +515,7 @@ exif_mnote_data_olympus_load (ExifMnoteData *en,
 				continue;
 			}
 			memcpy (n->entries[tcount].data, buf + dataofs, s);
+			copied_size += s;
 		}
 
 		/* Tag was successfully parsed */

--- a/libexif/pentax/exif-mnote-data-pentax.c
+++ b/libexif/pentax/exif-mnote-data-pentax.c
@@ -219,7 +219,7 @@ exif_mnote_data_pentax_load (ExifMnoteData *en,
 		const unsigned char *buf, unsigned int buf_size)
 {
 	ExifMnoteDataPentax *n = (ExifMnoteDataPentax *) en;
-	size_t i, tcount, o, datao, base = 0;
+	size_t i, tcount, o, datao, base = 0, copied_size = 0;
 	ExifShort c;
 
 	if (!n) return;
@@ -336,6 +336,12 @@ exif_mnote_data_pentax_load (ExifMnoteData *en,
 					  "of buffer (%u > %u)", (unsigned)(dataofs + s), buf_size);
 				continue;
 			}
+			if (s > buf_size - copied_size) {
+				exif_log (en->log, EXIF_LOG_CODE_CORRUPT_DATA,
+						  "ExifMnoteDataPentax",
+						  "MakerNote data exceeds input size");
+				break;
+			}
 
 			n->entries[tcount].data = exif_mem_alloc (en->mem, s);
 			if (!n->entries[tcount].data) {
@@ -343,6 +349,7 @@ exif_mnote_data_pentax_load (ExifMnoteData *en,
 				continue;
 			}
 			memcpy (n->entries[tcount].data, buf + dataofs, s);
+			copied_size += s;
 		}
 
 		/* Tag was successfully parsed */


### PR DESCRIPTION
MakerNote entries can reference the same raw EXIF range multiple times. The Canon, Fuji, Olympus, and Pentax loaders copied each reference independently, allowing a raw EXIF input to amplify memory consumption and exhaust the calling process.

Track bytes copied while decoding each MakerNote and stop parsing when the total would exceed the supplied input size. This preserves valid in-bounds offset handling while bounding decoded MakerNote data to the caller's buffer.
