### PR TITLE
exif-data: avoid repeated loading of pointer-only IFDs

### DIFF
--- a/libexif/exif-data.c
+++ b/libexif/exif-data.c
@@ -361,7 +361,7 @@ if ((i) == ifd) {				\
 		exif_ifd_get_name (i));			\
 	break;						\
 }							\
-if (data->ifd[(i)]->count) {				\
+if ((*visited_ifds & (1U << (i))) || data->ifd[(i)]->count) {				\
 	exif_log (data->priv->log, EXIF_LOG_CODE_DEBUG,	\
 		"ExifData", "Attempt to load IFD "	\
 		"'%s' multiple times detected. "	\
@@ -397,7 +397,8 @@ level_cost(unsigned int n)
 static void
 exif_data_load_data_content (ExifData *data, ExifIfd ifd,
 			     const unsigned char *d,
-			     unsigned int ds, unsigned int offset, unsigned int recursion_cost)
+			     unsigned int ds, unsigned int offset, unsigned int recursion_cost,
+			     unsigned int *visited_ifds)
 {
 	ExifLong o, thumbnail_offset = 0, thumbnail_length = 0;
 	ExifShort n;
@@ -447,6 +448,11 @@ exif_data_load_data_content (ExifData *data, ExifIfd ifd,
 				  "Short data; only loading %hu entries...", n);
 	}
 
+	/* Mark this IFD before following any of its pointers. Pointer-only IFDs
+	 * do not add entries to ExifContent, so count cannot act as a reliable
+	 * visited marker while recursive loading is in progress. */
+	*visited_ifds |= 1U << ifd;
+
 	for (i = 0; i < n; i++) {
 
 		tag = exif_get_short (d + offset + 12 * i, data->priv->order);
@@ -475,17 +481,17 @@ exif_data_load_data_content (ExifData *data, ExifIfd ifd,
 			case EXIF_TAG_EXIF_IFD_POINTER:
 				CHECK_REC (EXIF_IFD_EXIF)
 				exif_data_load_data_content (data, EXIF_IFD_EXIF, d, ds, o,
-					recursion_cost + level_cost(n));
+					recursion_cost + level_cost(n), visited_ifds);
 				break;
 			case EXIF_TAG_GPS_INFO_IFD_POINTER:
 				CHECK_REC (EXIF_IFD_GPS)
 				exif_data_load_data_content (data, EXIF_IFD_GPS, d, ds, o,
-					recursion_cost + level_cost(n));
+					recursion_cost + level_cost(n), visited_ifds);
 				break;
 			case EXIF_TAG_INTEROPERABILITY_IFD_POINTER:
 				CHECK_REC (EXIF_IFD_INTEROPERABILITY)
 				exif_data_load_data_content (data, EXIF_IFD_INTEROPERABILITY, d, ds, o,
-					recursion_cost + level_cost(n));
+					recursion_cost + level_cost(n), visited_ifds);
 				break;
 			case EXIF_TAG_JPEG_INTERCHANGE_FORMAT:
 				thumbnail_offset = o;
@@ -857,6 +863,7 @@ exif_data_load_data (ExifData *data, const unsigned char *d_orig,
 		     unsigned int ds)
 {
 	unsigned int l;
+	unsigned int visited_ifds = 0;
 	ExifLong offset;
 	ExifShort n;
 	const unsigned char *d = d_orig;
@@ -1003,7 +1010,7 @@ exif_data_load_data (ExifData *data, const unsigned char *d_orig,
 		return;
 
 	/* Parse the actual exif data (usually offset 14 from start) */
-	exif_data_load_data_content (data, EXIF_IFD_0, d + 6, ds - 6, offset, 0);
+	exif_data_load_data_content (data, EXIF_IFD_0, d + 6, ds - 6, offset, 0, &visited_ifds);
 
 	/* IFD 1 offset */
 	n = exif_get_short (d + 6 + offset, data->priv->order);
@@ -1021,7 +1028,7 @@ exif_data_load_data (ExifData *data, const unsigned char *d_orig,
 			exif_log (data->priv->log, EXIF_LOG_CODE_CORRUPT_DATA,
 				  "ExifData", "Bogus offset of IFD1.");
 		} else {
-		   exif_data_load_data_content (data, EXIF_IFD_1, d + 6, ds - 6, offset, 0);
+		   exif_data_load_data_content (data, EXIF_IFD_1, d + 6, ds - 6, offset, 0, &visited_ifds);
 		}
 	}
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -34,13 +34,13 @@ endif
 #      here yet.
 
 TESTS = test-mem test-value test-integers test-parse test-parse-from-data test-tagtable test-sorted \
-	test-fuzzer test-null test-gps parse-regression.sh swap-byte-order.sh \
+	test-fuzzer test-ifd-reentry test-null test-gps parse-regression.sh swap-byte-order.sh \
 	extract-parse.sh check-mnote.sh
 
 TESTS += check-failmalloc.sh
 
 check_PROGRAMS = test-mem test-mnote test-value test-integers test-parse test-parse-from-data \
-	test-tagtable test-sorted test-fuzzer test-extract test-null test-gps
+	test-tagtable test-sorted test-fuzzer test-ifd-reentry test-extract test-null test-gps
 
 LDADD = $(top_builddir)/libexif/libexif.la $(LTLIBINTL)
 

--- a/test/test-ifd-reentry.c
+++ b/test/test-ifd-reentry.c
@@ -1,0 +1,105 @@
+/* Regression test for repeated recursive loading of pointer-only IFDs. */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "libexif/exif-data.h"
+#include "libexif/exif-log.h"
+
+#define EXIF_PTR 0x8769
+#define GPS_PTR 0x8825
+#define INTEROP_PTR 0xa005
+#define FANOUT 2
+#define IFD_SIZE (2 + FANOUT * 12 + 4)
+#define TIFF_SIZE (8 + 4 * IFD_SIZE)
+#define EXIF_SIZE (6 + TIFF_SIZE)
+
+static unsigned int ifd_load_count;
+
+static void put16(unsigned char *p, unsigned int v)
+{
+    p[0] = (unsigned char)v;
+    p[1] = (unsigned char)(v >> 8);
+}
+
+static void put32(unsigned char *p, unsigned int v)
+{
+    p[0] = (unsigned char)v;
+    p[1] = (unsigned char)(v >> 8);
+    p[2] = (unsigned char)(v >> 16);
+    p[3] = (unsigned char)(v >> 24);
+}
+
+static void write_pointer_ifd(unsigned char *tiff, unsigned int offset,
+                              unsigned int tag, unsigned int target)
+{
+    unsigned int i;
+    unsigned char *p = tiff + offset;
+
+    put16(p, FANOUT);
+    p += 2;
+
+    for (i = 0; i < FANOUT; ++i, p += 12) {
+        put16(p, tag);
+        put16(p + 2, 4); /* LONG */
+        put32(p + 4, 1);
+        put32(p + 8, target);
+    }
+
+    put32(p, 0); /* no next IFD */
+}
+
+static void log_func(ExifLog *log, ExifLogCode code, const char *domain,
+                     const char *format, va_list args, void *data)
+{
+    (void)log;
+    (void)code;
+    (void)domain;
+    (void)args;
+    (void)data;
+
+    if (!strcmp(format, "Loading %hu entries..."))
+        ++ifd_load_count;
+}
+
+int main(void)
+{
+    unsigned char exif[EXIF_SIZE] = {0};
+    unsigned char *tiff = exif + 6;
+    const unsigned int ifd0 = 8;
+    const unsigned int ifd_exif = ifd0 + IFD_SIZE;
+    const unsigned int ifd_gps = ifd_exif + IFD_SIZE;
+    const unsigned int ifd_interop = ifd_gps + IFD_SIZE;
+    ExifData *data;
+    ExifLog *log;
+
+    memcpy(exif, "Exif\0\0", 6);
+    memcpy(tiff, "II", 2);
+    put16(tiff + 2, 42);
+    put32(tiff + 4, ifd0);
+
+    write_pointer_ifd(tiff, ifd0, EXIF_PTR, ifd_exif);
+    write_pointer_ifd(tiff, ifd_exif, GPS_PTR, ifd_gps);
+    write_pointer_ifd(tiff, ifd_gps, INTEROP_PTR, ifd_interop);
+    write_pointer_ifd(tiff, ifd_interop, EXIF_PTR, ifd_exif);
+
+    data = exif_data_new();
+    log = exif_log_new();
+    if (!data || !log)
+        return 2;
+
+    exif_log_set_func(log, log_func, NULL);
+    exif_data_log(data, log);
+    exif_data_load_data(data, exif, sizeof(exif));
+
+    exif_data_unref(data);
+    exif_log_unref(log);
+
+    if (ifd_load_count != 4) {
+        fprintf(stderr, "expected 4 unique IFD loads, got %u\n", ifd_load_count);
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

Prevent repeated recursive loading of the same logical IFD when an EXIF file contains pointer-only IFDs.

`CHECK_REC` currently uses `data->ifd[target]->count` to decide whether an IFD was already loaded. Pointer tags are handled specially and are not inserted into `ExifContent`, so an IFD containing only pointers keeps `count == 0`. Repeated pointers can therefore re-enter the same EXIF/GPS/Interoperability IFD across recursive branches until the existing recursion-cost limiter stops each branch.

This adds an internal per-parse IFD visited bitmask. An IFD is marked before its pointers are followed, and `CHECK_REC` rejects either an already-visited IFD or one whose content is already populated.

## Reproduction

I constructed a 134-byte EXIF/TIFF blob with two pointers per IFD and this cycle:

`IFD0 -> EXIF -> GPS -> Interoperability -> EXIF`

On current `master` (`aebe2a7b61a2fcd95f8d72e2d317027faf73fdc1`), an optimized GCC 15.2 build spends about **3.525 seconds of CPU** parsing this 134-byte input.

A regression test counts the existing `Loading %hu entries...` log event:

- current master: **4,194,303 IFD loads**, test fails
- this change: **4 IFD loads**, test passes and parsing is effectively immediate

## Compatibility / tests

- Added `test-ifd-reentry` to `make check`.
- Parsed/dumped all 18 repository testdata files with untouched master and this change; output is byte-identical (88,184 bytes, SHA-256 `B611E6AD3268984AA2D52D4A80596C0698DB9F7D6712DE7A335929F9D89E4D35`).
- `test-mem`, `test-value`, `test-integers`, `test-tagtable`, `test-sorted`, `test-null`, `test-gps`, and `test-ifd-reentry` all pass locally.
- Focused GCC `-Wall -Wextra -Wpedantic` build is clean.
- `git diff --check` is clean.

## Security context

This is resource-exhaustion hardening for untrusted EXIF blobs, which the project's security policy treats as an attack surface. It is related to the long-open OSS-Fuzz recursion DoS issue #55.

The current logarithmic recursion-cost model was introduced by `6aa11df` for CVE-2018-20030 because an earlier depth-only defense still allowed CPU DoS. This change does **not** claim a new vulnerability family; it addresses a concrete remaining gap where pointer-only IFDs evade the loader's existing duplicate-IFD check.

I could not retrieve the original 2021 OSS-Fuzz testcase, so the performance numbers above are from the independent minimized structure described here rather than a claim that the original corpus has been reproduced byte-for-byte.
